### PR TITLE
Adding boolean and making calculate params optional

### DIFF
--- a/Model/Datasource/ElasticSource.php
+++ b/Model/Datasource/ElasticSource.php
@@ -657,6 +657,9 @@ class ElasticSource extends DataSource {
 				case 'geo_point':
 					$filter = $this->geo($key, $operator, $value);
 					break;
+				case 'boolean':
+					$filter = $this->term($key, $operator, $value);
+					break;
 				default:
 					throw new Exception("Unable to process field of type '$type' for key '$key'");
 			}


### PR DESCRIPTION
Adding the boolean type to the query builder

Also ran into an instance where the calculate was throwing an error with there not being any params being passed.
