### PR TITLE
Return false if a record does not exist

### DIFF
--- a/Model/Datasource/ElasticSource.php
+++ b/Model/Datasource/ElasticSource.php
@@ -1444,6 +1444,10 @@ class ElasticSource extends DataSource {
 			return $this->_throwError($body);
 		}
 
+		if (isset($body->exists) && $body->exists === false) {
+			return false;
+		}
+
 		if (!empty($body->ok) && $body->ok == true) {
 			return true;
 		}


### PR DESCRIPTION
Checks if `exists` key is set and returns false if the value of `exists` is false.
