### PR TITLE
Fixing issue where count was not working on ElasticSearch 1.*

### DIFF
--- a/Model/Datasource/ElasticSource.php
+++ b/Model/Datasource/ElasticSource.php
@@ -725,7 +725,7 @@ class ElasticSource extends DataSource {
 		$query = compact('query', 'size', 'sort', 'from', 'fields', 'script_fields', 'facets');
 
 		if ($Model->findQueryType === 'count') {
-			return $query['query'];
+			return (!empty($this->config['filteredCount']) ? ['query' => $query['query']] : $query['query']);
 		}
 
 		return $query;
@@ -1731,4 +1731,3 @@ class ElasticSource extends DataSource {
 		return $table;
 	}
 }
-


### PR DESCRIPTION
Currently this datasource produces always a count of `0` when issuing a `count` query against an ElasticSearch 1.* server. This is because filtered queries in ES require the filter to be wrapped in a query, particularly when issuing a `_count` call, and the datasource is currently taking out the outer query part.

Since this is a BC change for older version of ES, I introduced a new connection option named `filteredCount`. When this option is set to `true`, filtered queries will be wrapped in a query when issuing a `_count` call. Therefore all ES 1.* connections should set this option to `true`.