### PR TITLE
Fixing Notice when a PUT request's response includes an _id but not a _source field

### DIFF
--- a/Model/Datasource/ElasticSource.php
+++ b/Model/Datasource/ElasticSource.php
@@ -1530,7 +1530,7 @@ class ElasticSource extends DataSource {
 			}
 			return $results['hits']['hits'];
 		}
-		if (!empty($results['_id'])) {
+		if (!empty($results['_id']) && !empty($results['_source'])) {
 			$model = $results['_source'];
 			if (empty($model[$this->currentModel->alias][$this->currentModel->primaryKey])) {
 				$model[$this->currentModel->alias][$this->currentModel->primaryKey] = $results['_id'];


### PR DESCRIPTION
Responses to PUT requests without a _source field raised a notice. 
